### PR TITLE
feat: Implement UI triggers for GitHub and LinkedIn data sync

### DIFF
--- a/src/components/dashboard/IntegrationCard.tsx
+++ b/src/components/dashboard/IntegrationCard.tsx
@@ -17,6 +17,7 @@ type IntegrationCardProps = {
   isConnected: boolean;
   onConnect: () => void;
   onDisconnect: () => void;
+  onSyncData?: () => Promise<void>;
   loading?: boolean;
   lastSynced?: string | null;
   profileData?: any;
@@ -29,6 +30,7 @@ export default function IntegrationCard({
   isConnected,
   onConnect,
   onDisconnect,
+  onSyncData,
   loading = false,
   lastSynced,
   profileData,
@@ -136,9 +138,7 @@ export default function IntegrationCard({
               <Button
                 variant="ghost"
                 size="icon"
-                onClick={() => {
-                  /* TODO: Implement sync */
-                }}
+                onClick={onSyncData}
                 disabled={loading}
                 title="Sync data"
               >

--- a/src/components/dashboard/IntegrationsTab.tsx
+++ b/src/components/dashboard/IntegrationsTab.tsx
@@ -41,6 +41,39 @@ export default function IntegrationsTab() {
     }
   };
 
+  const handleSyncLinkedIn = async () => {
+    try {
+      await syncLinkedIn();
+      toast({
+        title: "LinkedIn Sync Initiated",
+        description:
+          "Timestamp updated. Note: Full LinkedIn data sync requires special API permissions not yet enabled for this application.",
+      });
+    } catch (error) {
+      toast({
+        variant: "destructive",
+        title: "LinkedIn sync failed",
+        description: "There was an error attempting to sync with LinkedIn.",
+      });
+    }
+  };
+
+  const handleSyncGitHub = async () => {
+    try {
+      await syncGitHub();
+      toast({
+        title: "GitHub data sync started",
+        description: "Your GitHub data is being updated in the background.",
+      });
+    } catch (error) {
+      toast({
+        variant: "destructive",
+        title: "GitHub sync failed",
+        description: "There was an error syncing your GitHub data.",
+      });
+    }
+  };
+
   const handleDisconnectGithub = async () => {
     try {
       await disconnectGitHub();
@@ -114,6 +147,7 @@ export default function IntegrationsTab() {
           isConnected={githubConnected}
           onConnect={handleConnectGithub}
           onDisconnect={handleDisconnectGithub}
+          onSyncData={handleSyncGitHub}
           loading={githubLoading}
           lastSynced={githubProfile?.last_synced_at}
           profileData={githubProfile}
@@ -141,6 +175,7 @@ export default function IntegrationsTab() {
           isConnected={linkedinConnected}
           onConnect={handleConnectLinkedin}
           onDisconnect={handleDisconnectLinkedin}
+          onSyncData={handleSyncLinkedIn}
           loading={linkedinLoading}
           lastSynced={linkedinProfile?.last_synced_at}
           profileData={linkedinProfile}


### PR DESCRIPTION
This commit introduces the following changes:

- Enables the data synchronization button on the `IntegrationCard` component for both GitHub and LinkedIn integrations displayed in the `IntegrationsTab`.

GitHub Integration:
- You can now click the sync button on the GitHub integration card to trigger the `sync-github-data` Supabase edge function.
- Toast notifications are displayed to inform you about the sync initiation and success/failure.

LinkedIn Integration:
- You can click the sync button on the LinkedIn integration card. This action calls the `sync-linkedin-data` Supabase edge function.
- Toast notifications inform you about the sync initiation.
- Importantly, the success toast message for LinkedIn explicitly states that only a timestamp is updated due to current LinkedIn API limitations, and full data synchronization requires further API permissions.

The `IntegrationCard.tsx` component was updated to accept an `onSyncData` callback prop. The `IntegrationsTab.tsx` component was updated to provide `handleSyncGitHub` and `handleSyncLinkedIn` functions to their respective cards, including the logic for toast notifications.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enabled manual data synchronization for LinkedIn and GitHub integrations via a sync button on each integration card.
  - Added toast notifications to inform users of the success or failure of sync actions, with additional guidance for LinkedIn API permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->